### PR TITLE
打开hlsl相关功能注册，修复了HLSL Symbol解析的几个问题

### DIFF
--- a/scripts/extension.hlsl.ts
+++ b/scripts/extension.hlsl.ts
@@ -9,22 +9,22 @@ import { registerWorkspaceSymbolProvider } from './shared.WorkspaceSymbolProvide
 import { registerSymbolCache } from './shared.SymbolCache.js';
 
 const activate = (context: vscode.ExtensionContext) => {
-    // // 符号提供
-    // registerDocumentSymbolProvider(context);
-    // // #include 跳转
-    // registerDocumentLinkProvider(context);
+    // 符号提供
+    registerDocumentSymbolProvider(context);
+    // #include 跳转
+    registerDocumentLinkProvider(context);
     // 格式化
     registerDocumentFormattingEditProvider(context);
-    // // 定义跳转
-    // registerDefinitionProvider(context);
-    // // 自动完成
-    // registerCompletionItemProvider(context);
-    // // 悬停提示
-    // registerHoverProvider(context);
-    // // 工作区符号搜索
-    // registerWorkspaceSymbolProvider(context);
-    // // 符号缓存
-    // registerSymbolCache(context);                      
+    // 定义跳转
+    registerDefinitionProvider(context);
+    // 自动完成
+    registerCompletionItemProvider(context);
+    // 悬停提示
+    registerHoverProvider(context);
+    // 工作区符号搜索
+    registerWorkspaceSymbolProvider(context);
+    // 符号缓存
+    registerSymbolCache(context);                      
 
     console.log('HLSL language support activated');
 }

--- a/scripts/hlsl.DefinitionProvider.ts
+++ b/scripts/hlsl.DefinitionProvider.ts
@@ -189,18 +189,22 @@ const provideDefinition = async (
         return [chainResult];
     }
 
+    /**
+     * todo: 在unity中hlsl文件通常有明确的头文件引用关系，暂时屏蔽工作区和Unity CGIncludes的查找
+     * 未来可以考虑做成可选配置项（从.shader文件建立头文件依赖图）
+     *
     // 2. 在工作区中查找
     const workspaceResult = await findDefinitionInWorkspace(word);
     if (workspaceResult) {
         return [workspaceResult];
     }
-
+    * hlsl 不使用 Builtin管线的CGIncludes 库
     // 3. 在 Unity CGIncludes 中查找
     const unityResult = await findDefinitionInUnityIncludes(word);
     if (unityResult) {
         return [unityResult];
     }
-
+    */
     return null;
 }
 

--- a/scripts/hlsl.DocumentSymbolProvider.ts
+++ b/scripts/hlsl.DocumentSymbolProvider.ts
@@ -36,6 +36,75 @@ const isHLSLType = (typeName: string): boolean => {
 }
 
 /**
+ * 找到匹配的右大括号位置
+ * @param text 文本内容
+ * @param startPos 起始位置（左大括号的位置）
+ * @returns 匹配的右大括号位置，如果未找到返回 -1
+ */
+function findMatchingBrace(text: string, startPos: number): number {
+    let depth = 1;
+    let inString = false;
+    let inChar = false;
+    let inLineComment = false;
+    let inBlockComment = false;
+
+    for (let i = startPos + 1; i < text.length; i++) {
+        const char = text[i];
+        const prevChar = i > 0 ? text[i - 1] : '';
+
+        // 处理行注释
+        if (!inString && !inChar && !inBlockComment && char === '/' && text[i + 1] === '/') {
+            inLineComment = true;
+            continue;
+        }
+        if (inLineComment && char === '\n') {
+            inLineComment = false;
+            continue;
+        }
+
+        // 处理块注释
+        if (!inString && !inChar && !inLineComment && char === '/' && text[i + 1] === '*') {
+            inBlockComment = true;
+            i++;
+            continue;
+        }
+        if (inBlockComment && char === '*' && text[i + 1] === '/') {
+            inBlockComment = false;
+            i++;
+            continue;
+        }
+
+        // 跳过注释内的字符
+        if (inLineComment || inBlockComment) continue;
+
+        // 处理字符串
+        if (char === '"' && prevChar !== '\\') {
+            inString = !inString;
+            continue;
+        }
+        if (char === "'" && prevChar !== '\\') {
+            inChar = !inChar;
+            continue;
+        }
+
+        // 跳过字符串内的字符
+        if (inString || inChar) continue;
+
+        // 统计大括号深度
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return i;
+            }
+        }
+    }
+
+    return -1; // 未找到匹配的大括号
+}
+
+/**
  * 创建 DocumentSymbol
  */
 const createSymbol = (
@@ -142,7 +211,7 @@ const parseHLSLSymbols = (document: vscode.TextDocument): vscode.DocumentSymbol[
         symbols.push(cbufferSymbol);
     }
 
-    // 3. 解析函数定义（改进版：支持更多参数修饰符）
+    // 3. 解析函数定义（改进版：支持更多参数修饰符，并解析函数体内的局部变量）
     const regex_function = /\b(\w+)\s+(\w+)\s*\(\s*([^)]*)\s*\)(?:\s*:\s*(\w+))?\s*\{/g;
     while ((match = regex_function.exec(text)) !== null) {
         const returnType = match[1];
@@ -158,10 +227,16 @@ const parseHLSLSymbols = (document: vscode.TextDocument): vscode.DocumentSymbol[
         let detail = returnType;
         if (semantic) detail += ` : ${semantic}`;
 
+        // 找到函数体的范围（匹配大括号）
+        const funcBodyStart = match.index + match[0].length - 1; // '{' 的位置
+        const funcBodyEnd = findMatchingBrace(text, funcBodyStart);
+        const funcBody = funcBodyEnd > funcBodyStart ? text.substring(funcBodyStart + 1, funcBodyEnd) : '';
+
         const nameOffset = match[0].indexOf(funcName);
         const funcSymbol = createSymbol(
             document, funcName, detail, vscode.SymbolKind.Function,
-            match.index, match[0].length - 1, nameOffset, funcName.length
+            match.index, funcBodyEnd > funcBodyStart ? funcBodyEnd - match.index + 1 : match[0].length,
+            nameOffset, funcName.length
         );
 
         // 解析函数参数
@@ -189,6 +264,30 @@ const parseHLSLSymbols = (document: vscode.TextDocument): vscode.DocumentSymbol[
                     funcSymbol.children.push(paramSymbol);
                 }
                 paramOffset += paramPart.length + 1;
+            }
+        }
+
+        // 解析函数体内的局部变量声明
+        if (funcBody) {
+            const localVarRegex = /\b(\w+)\s+(\w+)(?:\s*=\s*[^;]+)?\s*;/g;
+            let localVarMatch: RegExpExecArray | null;
+
+            while ((localVarMatch = localVarRegex.exec(funcBody)) !== null) {
+                const varType = localVarMatch[1];
+                const varName = localVarMatch[2];
+
+                // 排除控制流关键字
+                if (['if', 'for', 'while', 'switch', 'return', 'break', 'continue', 'discard'].includes(varType)) continue;
+                
+                // 只保留已知的 HLSL 类型或自定义类型（首字母大写）
+                if (!isHLSLType(varType) && !/^[A-Z]/.test(varType)) continue;
+
+                const varSymbol = createSymbol(
+                    document, varName, varType, vscode.SymbolKind.Variable,
+                    funcBodyStart + 1 + localVarMatch.index, localVarMatch[0].length,
+                    localVarMatch[0].indexOf(varName), varName.length
+                );
+                funcSymbol.children.push(varSymbol);
             }
         }
 

--- a/scripts/shaderlab.DocumentSymbolProvider.ts
+++ b/scripts/shaderlab.DocumentSymbolProvider.ts
@@ -171,6 +171,8 @@ const SemanticTokens_CGPROGRAM = (rangeInfo: SemanticTokenRangeInfo, parentSymbo
 
         const end = match[0].length - 1 + match.index + bracketInfo.start;
         const bracket = bracketInfo.children.find(item => item.start == end);
+        if (!bracket || bracket.end == null)
+            continue;
         const range = new vscode.Range(
             document.positionAt(match.index + bracketInfo.start),
             document.positionAt(bracket.end));
@@ -194,6 +196,8 @@ const SemanticTokens_CGPROGRAM = (rangeInfo: SemanticTokenRangeInfo, parentSymbo
 
         const end = bracketInfo.start + match.index + match[0].length - 1;
         const bracket = bracketInfo.children.find(item => item.start == end);
+        if (!bracket || bracket.end == null)
+            continue;
         const range = new vscode.Range(
             document.positionAt(bracketInfo.start + match.index),
             document.positionAt(bracket.end));
@@ -269,6 +273,8 @@ const SemanticTokens_SubShader = (rangeInfo: SemanticTokenRangeInfo, parentSymbo
 
         const end = match[0].length - 1 + match.index + bracketInfo.start;
         const bracket = bracketInfo.children.find(item => item.start == end);
+        if (!bracket || bracket.end == null)
+            continue;
         const range = new vscode.Range(
             document.positionAt(match.index + bracketInfo.start),
             document.positionAt(bracket.end));
@@ -317,14 +323,16 @@ const SemanticTokens_Shader = (rangeInfo: SemanticTokenRangeInfo, parentSymbol: 
 
         const end = match[0].length - 1 + match.index + bracketInfo.start;
         const bracket = bracketInfo.children.find(item => item.start == end);
-        const range = new vscode.Range(
-            document.positionAt(match.index + bracketInfo.start),
-            document.positionAt(bracket.end));
+        if (bracket && bracket.end != null) {
+            const range = new vscode.Range(
+                document.positionAt(match.index + bracketInfo.start),
+                document.positionAt(bracket.end));
 
-        const node = new vscode.DocumentSymbol('Properties', '', vscode.SymbolKind.Package, range, selectionRange);
-        parentSymbol.children.push(node);
+            const node = new vscode.DocumentSymbol('Properties', '', vscode.SymbolKind.Package, range, selectionRange);
+            parentSymbol.children.push(node);
 
-        SemanticTokens_Properties(rangeInfo, node, bracket);
+            SemanticTokens_Properties(rangeInfo, node, bracket);
+        }
     }
     const regex = /(SubShader)\s*{/ig;
     while (match = regex.exec(text)) {
@@ -336,6 +344,8 @@ const SemanticTokens_Shader = (rangeInfo: SemanticTokenRangeInfo, parentSymbol: 
 
         const end = match[0].length - 1 + match.index + bracketInfo.start;
         const bracket = bracketInfo.children.find(item => item.start == end);
+        if (!bracket || bracket.end == null)
+            continue;
         const range = new vscode.Range(
             document.positionAt(match.index + bracketInfo.start),
             document.positionAt(bracket.end));
@@ -359,6 +369,8 @@ const SemanticTokens_Root = (document: vscode.TextDocument, bracketInfo: Bracket
 
         const end = match[0].length - 1 + match.index + bracketInfo.start;
         const bracket = bracketInfo.children.find(item => item.start == end);
+        if (!bracket || bracket.end == null)
+            return null;
         const range = new vscode.Range(
             document.positionAt(match.index + bracketInfo.start),
             document.positionAt(bracket.end));


### PR DESCRIPTION
修复：Unity包名没有版本号导致找不到的情况

修复：在 DocumentSymbolProvider 中增加对 bracket 的空值检查

# Conflicts:
#	scripts/shaderlab.DocumentSymbolProvider.ts

修复：无法解析局部Symbol的问题

屏蔽了hlsl从工作区和CG库查找的代码

# Conflicts:
#	scripts/hlsl.DocumentSymbolProvider.ts